### PR TITLE
add "statping"

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,7 @@ Comparison of NoSQL servers: http://kkovacs.eu/cassandra-vs-mongodb-vs-couchdb-v
 * [System Status Dashboard (SSD)](http://www.system-status-dashboard.com/) - Overview about an organization's infrastructure health status.
 * [Staytus](http://staytus.co/) - Staytus is a complete solution for publishing the latest information about any issues with your web applications, networks or services.
 * [vigil](https://github.com/valeriansaliou/vigil) -  Microservices Status Page. Monitors a distributed infrastructure and sends alerts to Slack. Written in Rust.
+* [Statping](https://github.com/hunterlong/statping) - Status page system written in Go.
 
 ## Troubleshooting
 


### PR DESCRIPTION
### Application name / category
[Statping](https://github.com/hunterlong/statping) / Status Pages

### Source URL
https://github.com/hunterlong/statping

### why it is awesome
This tool is so awesome because it allows me to do monitor my company servers and services and development teams can be aware of the situation real time!
